### PR TITLE
Add new train options, increase sequence length

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -50,6 +50,8 @@ def lyrics(args):
 
     tokenizer = util.load_tokenizer(args.tokenizer)
 
+    print('Generating lyrics from "{}..."'.format(args.text))
+
     raw, text = generate_lyrics(model, tokenizer, args.text, args.length, args.randomness)
     if args.print_raw:
         print(raw)

--- a/lyrics/embedding.py
+++ b/lyrics/embedding.py
@@ -53,11 +53,11 @@ def create_word2vec(data_dir='./data',
 def create_embedding_mappings(embedding_file=config.EMBEDDING_FILE):
     """Create a lookup dictionary for word embeddings from the given embeddings file."""
     print('Loading embedding mapping file {}'.format(embedding_file))
-    glove = pd.read_table(embedding_file, sep=' ', index_col=0, header=None, quoting=csv.QUOTE_NONE)
+    embedding = pd.read_table(embedding_file, sep=' ', index_col=0, header=None, quoting=csv.QUOTE_NONE)
     mapping = {}
 
     print('Creating embedding mappings for faster lookup')
-    for row in glove.itertuples():
+    for row in embedding.itertuples():
         mapping[row[0]] = list(row[1:])
 
     return mapping

--- a/lyrics/train.py
+++ b/lyrics/train.py
@@ -12,13 +12,28 @@ import tensorflow as tf
 from . import config, embedding, util
 
 
-def prepare_data(songs, transform_words=False):
+def prepare_data(songs, transform_words=False, use_full_sentences=False):
+    """Prepare songs for training, including tokenizing and word preprocessing.
+
+    Parameters
+    ----------
+    songs : list
+        A list of song strings
+    transform_words : bool
+        Whether or not to transform certain words such as cannot -> can't
+    use_full_sentences : bool
+        Whether or not to only create full sentences, i.e. sentences where
+        all the tokenized words are non-zero.
+
+    """
     songs = util.prepare_songs(songs, transform_words=transform_words)
     tokenizer = util.prepare_tokenizer(songs)
 
     num_words = min(config.MAX_NUM_WORDS, len(tokenizer.word_index))
 
     print('Encoding all songs to integer sequences')
+    if use_full_sentences:
+        print('Note: Will only use full integer sequences!')
     now = datetime.datetime.now()
     songs_encoded = tokenizer.texts_to_sequences(songs)
     print('Took {}'.format(datetime.datetime.now() - now))
@@ -34,15 +49,27 @@ def prepare_data(songs, transform_words=False):
     print('Find the average line length for all songs')
     now = datetime.datetime.now()
     for song_encoded in songs_encoded:
-        # Find the index of the newline character.
-        # For double newlines (between verses), the distance will be 1
+        # Find the indices of the newline characters.
+        # For double newlines (between verses), the distance will be 1 so these
+        # distances are ignored...
+
+        # Note: np.where() returns indices when used only with a condition.
+        # Thus, these indices can be used to measure the distance between
+        # newlines.
         newline_indexes = np.where(np.array(song_encoded) == newline_int)[0]
+
         lengths = [
-            newline_indexes[i] - newline_indexes[i-1]
+            # Exclude the newline itself by subtracting 1 at the end...
+            newline_indexes[i] - newline_indexes[i-1] - 1
             for i in range(1, len(newline_indexes))
             if newline_indexes[i] - newline_indexes[i-1] > 1
         ]
         line_lengths.extend(lengths)
+
+        # There are no newlines at the beginning and end of the song, so add those line lengths
+        line_lengths.append(newline_indexes[0]) # The length of the first line is just the index of the newline...
+        line_lengths.append(len(song_encoded) - newline_indexes[-1] - 1)
+
     print('Took {}'.format(datetime.datetime.now() - now))
     print()
 
@@ -53,15 +80,17 @@ def prepare_data(songs, transform_words=False):
     print()
 
     # Prepare input data based on the median sequence length
-    # Take two average linex (hence the multiplication by 2)
-    seq_length = int(round(median_seq_length)) * 2
+    # Take 4 average lines (hence the multiplication by 4)
+    # And assume a newline character between each (hence the + 3)
+    seq_length = int(round(median_seq_length)) * 4 + 3
 
     # Prepare data for training
     X, y = [], []
     print('Creating test data')
     now = datetime.datetime.now()
     for song_encoded in songs_encoded:
-        for i in range(1, len(song_encoded)):
+        start_index = seq_length if use_full_sentences else 1
+        for i in range(start_index, len(song_encoded)):
             seq = song_encoded[:i]
             # Manually pad/slice the sequences to the proper length
             # This avoids an expensive call to pad_sequences afterwards.
@@ -78,7 +107,12 @@ def prepare_data(songs, transform_words=False):
     return X, y, seq_length, num_words, tokenizer
 
 
-def create_model(seq_length, num_words, embedding_matrix, embedding_dim=config.EMBEDDING_DIM):
+def create_model(
+        seq_length,
+        num_words,
+        embedding_matrix,
+        embedding_dim=config.EMBEDDING_DIM,
+        embedding_not_trainable=False):
     # The + 1 accounts for the OOV token
     actual_num_words = num_words + 1
 
@@ -88,7 +122,7 @@ def create_model(seq_length, num_words, embedding_matrix, embedding_dim=config.E
         output_dim=embedding_dim,
         input_length=seq_length,
         weights=[embedding_matrix],
-        mask_zero=True)(inp)
+        mask_zero=True, name='song_embedding')(inp)
     x = tf.keras.layers.GRU(128, return_sequences=True)(x)
     x = tf.keras.layers.GRU(128, dropout=0.2, recurrent_dropout=0.2)(x)
     x = tf.keras.layers.Dense(128, activation='relu')(x)
@@ -96,6 +130,10 @@ def create_model(seq_length, num_words, embedding_matrix, embedding_dim=config.E
     outp = tf.keras.layers.Dense(actual_num_words, activation='softmax')(x)
 
     model = tf.keras.models.Model(inputs=[inp], outputs=[outp])
+
+    if embedding_not_trainable:
+        model.get_layer('song_embedding').trainable = False
+
     model.compile(
         loss='sparse_categorical_crossentropy',
         optimizer='rmsprop',
@@ -111,7 +149,9 @@ def train(epochs=100,
           artists=config.ARTISTS,
           embedding_file=config.EMBEDDING_FILE,
           embedding_dim=config.EMBEDDING_DIM,
-          transform_words=False):
+          embedding_not_trainable=False,
+          transform_words=False,
+          use_full_sentences=False):
     if export_dir is None:
         export_dir = './export/{}'.format(datetime.datetime.now().isoformat(timespec='seconds'))
         os.makedirs(export_dir, exist_ok=True)
@@ -122,7 +162,8 @@ def train(epochs=100,
     
     X, y, seq_length, num_words, tokenizer = prepare_data(
         songs,
-        transform_words=transform_words)
+        transform_words=transform_words,
+        use_full_sentences=use_full_sentences)
 
     # Make sure tokenizer is pickled, in case we need to
     util.pickle_tokenizer(tokenizer, export_dir)
@@ -133,7 +174,12 @@ def train(epochs=100,
         embedding_dim=embedding_dim,
         max_num_words=num_words)
 
-    model = create_model(seq_length, num_words, embedding_matrix, embedding_dim=embedding_dim)
+    model = create_model(
+        seq_length,
+        num_words,
+        embedding_matrix,
+        embedding_dim=embedding_dim,
+        embedding_not_trainable=embedding_not_trainable)
 
     # Run the training
     model.fit(np.array(X),
@@ -157,11 +203,33 @@ if __name__ == '__main__':
         default=config.EMBEDDING_FILE,
         help='Use a custom embedding file')
     parser.add_argument(
+        '--embedding-not-trainable',
+        action='store_true',
+        help="""
+            Whether the embedding weights are trainable or locked to the
+            vectors of the embedding file. It is only recommend to set this
+            flag if the embedding file contains vectors for the full
+            vocabulary of the songs.
+        """)
+    parser.add_argument(
         '--transform-words',
         action='store_true',
         help="""
             To clean the song texts a little bit more than normal by e.g.
             transforming certain words like runnin' to running.
         """)
+    parser.add_argument(
+        '--use-full-sentences',
+        action='store_true',
+        help="""
+            Use only full sentences as training input to the model, i.e. no
+            single-word vectors will be used for training. This decreases the
+            training data, and avoids putting emphasis on single starting
+            words in a song.
+        """)
     args = parser.parse_args()
-    train(embedding_file=args.embedding_file, transform_words=args.transform_words)
+    train(
+        embedding_file=args.embedding_file,
+        transform_words=args.transform_words,
+        use_full_sentences=args.use_full_sentences,
+        embedding_not_trainable=args.embedding_not_trainable)

--- a/tests/train_test.py
+++ b/tests/train_test.py
@@ -1,7 +1,82 @@
 """End to end train testing."""
 import os
 
+import numpy as np
+
 from lyrics import train
+
+
+# Created by Gene Lyrica One :-)
+# Modified slightly from original
+longer_song = """
+hello world is a dream
+i know when i been like your love
+and i can't go home
+
+i cannot cry
+i don't want to see
+i don't know why i can't run
+i got me
+"""
+
+
+def test_prepare_data_transform_words():
+    """It should prepare song data and transform words"""
+    songs = [longer_song]
+    x, y, seq_length, num_words, tokenizer = train.prepare_data(songs, transform_words=True)
+
+    # Average length is five words
+    # Median length is also five words
+    # We should thus expect a sequence length of 23 (4 sentences + 3 newline character)
+    assert seq_length == 23
+
+    # There are 25 words plus the newline character...
+    assert num_words == 26
+
+    # The newline character should be in the tokenizer's word index
+    assert '\n' in tokenizer.word_index
+
+    # "Cannot" should not exist anymore because of the transformed words
+    assert 'cannot' not in tokenizer.word_index
+    assert 'Cannot' not in tokenizer.word_index
+    assert 'can\'t' in tokenizer.word_index
+
+    # The first X will contain just the "hello" word and the target would be "world"
+    hello = tokenizer.word_index['hello']
+    world = tokenizer.word_index['world']
+    assert x[0][-1] == hello
+    assert y[0] == world
+
+
+def test_prepare_data_limit_zeros():
+    """It should prepare song data and transform words"""
+    songs = [longer_song]
+    x, y, seq_length, num_words, tokenizer = train.prepare_data(
+        songs,
+        transform_words=True,
+        use_full_sentences=True)
+
+    # Basic assumption are the same as the previous test.
+    assert seq_length == 23
+    assert num_words == 26
+
+    # The first X will contain no zeros
+    hello = tokenizer.word_index['hello']
+    world = tokenizer.word_index['world']
+    cant = tokenizer.word_index['can\'t']
+    me = tokenizer.word_index['me']
+    assert np.all(x[0])
+
+    # "can't" is the 24th word so with a sequence length of 23, it should be the first output.
+    assert x[0][0] == hello
+    assert x[0][1] == world
+    assert y[0] == cant
+
+    # "world" should be the first word in the second input sentence.
+    assert x[1][0] == world
+
+    # "me" is the last word so it should be the output of the last sequence...
+    assert y[-1] == me
 
 
 def test_train(export_dir, embedding_file, songfile):


### PR DESCRIPTION
This commit adds the following CLI options:
- Flag for locking making the embedding layer untrainable
- Flag for only using full vector sentences during training

Besides the extra flags, the sequence length is increased to include
four median sentences instead of two to allow for longer recurrent
memory.