### PR TITLE
Use Tensorflow 2.5 RC for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:2.4.1-gpu
+FROM tensorflow/tensorflow:2.5.0rc2-gpu
 
 WORKDIR /tf/src
 

--- a/lyrics/embedding.py
+++ b/lyrics/embedding.py
@@ -117,6 +117,11 @@ if __name__ == "__main__":
         "--name-suffix", default="", help="Name suffix for the embedding file."
     )
     parser.add_argument(
+        "--songdata-file",
+        default=config.SONGDATA_FILE,
+        help="Use a custom songdata file",
+    )
+    parser.add_argument(
         "--artists",
         default=config.ARTISTS,
         help="""
@@ -127,4 +132,6 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     artists = args.artists if args.artists != ["*"] else []
-    create_word2vec(name_suffix=args.name_suffix, artists=artists)
+    create_word2vec(
+        name_suffix=args.name_suffix, artists=artists, songdata_file=args.songdata_file
+    )


### PR DESCRIPTION
This commit fixes a GPU inference problem with Tensorflow 2.4.1 where a
trained model would return non-deterministic prediction results on GPU.
Updating to 2.5 magically solved this.

Bonus: Specify songdata file when creating an embedding